### PR TITLE
Fix nil ptr value panic

### DIFF
--- a/values/value.go
+++ b/values/value.go
@@ -54,6 +54,9 @@ func ValueOf(value interface{}) Value { // nolint: gocyclo
 	switch reflect.TypeOf(value).Kind() {
 	case reflect.Ptr:
 		rv := reflect.ValueOf(value)
+		if rv.IsNil() {
+			return nilValue
+		}
 		if rv.Type().Elem().Kind() == reflect.Struct {
 			return structValue{wrapperValue{value}}
 		}

--- a/values/value_test.go
+++ b/values/value_test.go
@@ -17,6 +17,13 @@ func TestValue_Interface(t *testing.T) {
 	require.Equal(t, 123, iv.Interface())
 }
 
+func TestValueNilPointer(t *testing.T) {
+	nv := ValueOf(func() *int {
+		return nil
+	}())
+	require.Nil(t, nv.Interface())
+}
+
 func TestValue_Equal(t *testing.T) {
 	iv := ValueOf(123)
 	require.True(t, iv.Equal(ValueOf(123)))


### PR DESCRIPTION
Hi there!

I have found "reflect: call of reflect.Value.Interface on zero Value" panic that occurred while executing a template with a structure that contains a pointer field with nil reference.

I used `{% if item.ElemID != null %} text about id {{ item.ElemID }}{% else %} text about null {% endif %}` in my template while `item.ElemID` has type *uint64 and equals nil, it panicked.

Full scratch:
```golang
package main

import (
	"fmt"
	"log"

	"github.com/arvata-io/liquid"
)

func main() {
	type Foo struct {
		Bar *uint64
	}
	engine := liquid.NewEngine()
	template := `text about{% if foo.Bar != null %} id {{ foo.Bar }}{% else %} null {% endif %}`
	out, err := engine.ParseAndRenderString(template, map[string]interface{}{
		"foo": Foo{},
	})
	if err != nil {
		log.Fatalln(err)
	}
	fmt.Println(out)
}
```